### PR TITLE
Fix problem when `#` in contest name

### DIFF
--- a/src/content.js
+++ b/src/content.js
@@ -15,7 +15,7 @@
     "action=" +
     "TEMPLATE" +
     "&text=" +
-    contestName +
+    encodeURIComponent(contestName) +
     "&dates=" +
     startTimeFormed +
     "/" +

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -10,7 +10,7 @@
   "manifest_version": 3,
   "name": "AtCoder Calendar",
   "short_name": "AC Calender",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "icons": {
     "16": "images/16icon.png",
     "48": "images/48icon.png",


### PR DESCRIPTION
[トヨタ自動車プログラミングコンテスト2023#3(AtCoder Beginner Contest 306)](https://atcoder.jp/contests/abc306) など、コンテスト名に `#` が含まれている場合にコンテスト名が `#` の前までと扱われてしまい、その際はdateやlocationも正しく扱われていないようでした。

こちらのPRの修正でコンテスト名、date、locationが `#` がない場合と同様に扱われるようになることを確認しています。

よければご確認お願いします。